### PR TITLE
plugins jar does not have .jar suffix

### DIFF
--- a/src/main/groovy/com/electriccloud/plugins/BuildPlugin.groovy
+++ b/src/main/groovy/com/electriccloud/plugins/BuildPlugin.groovy
@@ -233,7 +233,7 @@ class BuildPlugin implements Plugin<Project> {
 				outputs.upToDateWhen {
 					false
 				}
-				archiveName = project.name
+				archiveName = "${project.name}.jar"
 				destinationDir = new File("${project.buildDir}/${project.name}")
 				includeEmptyDirs = false
 				excludes = [


### PR DESCRIPTION
I know this needs to change. Unsure if my change fixes the problem as I
don't know how to build-test the gradle plugin locally.

Reference:
https://docs.gradle.org/current/dsl/org.gradle.api.tasks.bundling.Jar.html#org.gradle.api.tasks.bundling.Jar:archiveName
